### PR TITLE
Use Travis CI to ensure PEP8 compliance of all PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+group: travis_latest
+dist: xenial  # required for Python 3.7
+sudo: true    # required for Python 3.7
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.7
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    - flake8 . --count --max-complexity=10 --show-source --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
@juharris 

This configuration will cause Travis Continuous Integration to run [flake8](http://flake8.pycqa.org/en/latest/) tests on all future pull requests ensure there are no PEP8 violations.   For this to work, @Maluuba would have to turn __on__ the repo switch at https://travis-ci.org/Maluuba/FigureQA